### PR TITLE
update cpu-miner.c to include segwit on getblocktemplate params

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1377,10 +1377,11 @@ static const char *getwork_req =
 #define GBT_CAPABILITIES "[\"coinbasetxn\", \"coinbasevalue\", \"longpoll\", \"workid\"]"
 
 static const char *gbt_req =
-	"{\"method\": \"getblocktemplate\", \"params\": [{\"capabilities\": "
+	"{\"method\": \"getblocktemplate\", \"params\": [{\"rules\": [\"segwit\"], \"capabilities\": "
 	GBT_CAPABILITIES "}], \"id\":0}\r\n";
+
 static const char *gbt_lp_req =
-	"{\"method\": \"getblocktemplate\", \"params\": [{\"capabilities\": "
+	"{\"method\": \"getblocktemplate\", \"params\": [{\"rules\": [\"segwit\"], \"capabilities\": "
 	GBT_CAPABILITIES ", \"longpollid\": \"%s\"}], \"id\":0}\r\n";
 
 static bool get_upstream_work(CURL *curl, struct work *work)


### PR DESCRIPTION
JSON RPC call for getblocktemplate was failing on recent versions of Bitcoin Core (I'm using 25.0.0). Added "rules": ["segwit"] to  params on getblocktemplate and then it started mining without a hitch.